### PR TITLE
Added timeout option for Faraday connection

### DIFF
--- a/lib/carrierwave/attachmentscanner.rb
+++ b/lib/carrierwave/attachmentscanner.rb
@@ -4,9 +4,9 @@ require 'carrierwave/attachmentscanner/version'
 
 module CarrierWave
   module AttachmentScanner
-    Config = Struct.new(:url, :api_token, :enabled, :logger)
+    Config = Struct.new(:url, :api_token, :enabled, :logger, :timeout)
                    .new(ENV['ATTACHMENT_SCANNER_URL'], ENV['ATTACHMENT_SCANNER_API_TOKEN'],
-                     true, Logger.new(STDOUT))
+                     true, Logger.new(STDOUT), 60)
 
     DISABLED_WARNING = "[CarrierWave::AttachmentScanner] Disabled".freeze
 
@@ -77,6 +77,8 @@ module CarrierWave
 
     def scan_connection
       Faraday.new(Config.url) do |f|
+        f.options[:open_timeout] = Config.timeout
+        f.options[:timeout] = Config.timeout
         f.request :multipart
         f.request :url_encoded
         f.authorization :Bearer, Config.api_token

--- a/lib/generators/carrierwave_attachmentscanner/config/templates/config.rb.erb
+++ b/lib/generators/carrierwave_attachmentscanner/config/templates/config.rb.erb
@@ -11,4 +11,7 @@ CarrierWave::AttachmentScanner.configure do |config|
 
   # Disable in test and development environments
   # config.enabled = false if Rails.env.development? || Rails.env.test?
+
+  # Set a custom timeout for connections. Defaults to 60 seconds
+  # config.timeout = 60
 end


### PR DESCRIPTION
This PR adds a new `timeout` configuration variable that allows the user to fine-tune the timeout for specific needs.

Defaulted to 60 seconds.