### PR TITLE
Add support for Faraday 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in carrierwave-attachmentscan.gemspec
+# Specify your gem's dependencies in carrierwave-attachmentscanner.gemspec
 gemspec

--- a/carrierwave-attachmentscanner.gemspec
+++ b/carrierwave-attachmentscanner.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Scan carrierwave attachments using AttachmentScanner}
   spec.description   = %q{Automatically sends carrierwave uploads to AttachmentScanner to search for
     viruses, malware and other malicious files. }
-  spec.homepage      = "http://www.attachmentscanner.com"
+  spec.homepage      = "https://www.attachmentscanner.com"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "carrierwave"
-  spec.add_dependency "faraday"
-  spec.add_dependency "faraday_middleware"
+  spec.add_dependency "faraday", "~> 2.0"
+  spec.add_dependency "faraday-multipart"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This PR adds support for [Faraday 2.0](https://github.com/lostisland/faraday/blob/main/UPGRADING.md).

Faraday 2 introduces breaking API changes, so this update drops compatibility with Faraday 1.x. (thats why `"faraday", "~> 2.0"`)

Currently, the faraday_middleware dependency prevents upgrading Faraday to 2.0. This PR updates the Faraday-related code to be compatible with 2.0 and unblocks that upgrade.

I was not able to run the full spec suite in my environment, but manual testing indicates the changes behave as expected.

Please let me know if any additional changes or adjustments are needed.