### PR TITLE
Add GitHub Actions CI and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,0 +1,31 @@
+name: Specs
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['ruby', 'head']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run specs
+        env:
+          ATTACHMENT_SCANNER_URL: ${{ secrets.ATTACHMENT_SCANNER_URL || 'https://us-east-1.attachmentscanner.com' }}
+          ATTACHMENT_SCANNER_API_TOKEN: ${{ secrets.ATTACHMENT_SCANNER_API_TOKEN }}
+        run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Carrierwave::Attachmentscanner
 
-[![Build Status](https://travis-ci.org/attachmentscanner/carrierwave-attachmentscanner.svg?branch=master)](https://travis-ci.org/attachmentscanner/carrierwave-attachmentscanner)
+[![Specs](https://github.com/attachmentscanner/carrierwave-attachmentscanner/actions/workflows/specs.yml/badge.svg?branch=main)](https://github.com/attachmentscanner/carrierwave-attachmentscanner/actions/workflows/specs.yml) [![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.x-red?logo=ruby)](https://www.ruby-lang.org/)
 
 Carrierwave::Attachmentscanner allows you to scan any file uploaded by
 [CarrierWave](https://github.com/carrierwaveuploader/carrierwave) for viruses or


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow running specs across Ruby stable and head
- Adds Dependabot config for bundler and actions dependencies
- Updates README badge from Travis CI to GitHub Actions

## Test plan
- [ ] Verify workflow runs on this PR
- [ ] Confirm specs pass on both Ruby versions